### PR TITLE
Metadata, LDAP, SSP

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -1090,7 +1090,7 @@ $config = [
     'metadata.sign.privatekey' => null,
     'metadata.sign.privatekey_pass' => null,
     'metadata.sign.certificate' => null,
-    'metadata.sign.algorithm' => null,
+    'metadata.sign.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
 
 
     /****************************

--- a/dictionaries/idpinstaller.definition.json
+++ b/dictionaries/idpinstaller.definition.json
@@ -194,11 +194,20 @@
     "step5_ldap_referral": {
         "es": "Activar el seguimiento de referrals. Los controladores de dominio de Active Directory pueden requerir su desactivación para functionar correctamente"
     },
+    "step5_ldap_bindtext": {
+        "es": "En el caso de realizar bind anónimo especifique el DN y password:"
+    },
+    "step5_ldap_sspassword": {
+        "es": "¿Desea instalar y configurar la aplicación Self Service Password para que cada usuario pueda gestionar su contraseña?"
+    },
     "step5_ldap_timeout": {
         "es": "Timeout de acceso al LDAP, en segundos"
     },
     "step5_ldap_info": {
-        "es": "Esta configuración permitirá la conexión del IdP a la fuente de datos, pero no incluye la configuración de obtención de la información de la misma. Para configurar esta, se deberá seguir la documentación oficial de SimpleSAMLphp."
+        "es": "Esta configuración permitirá la conexión del IdP a la fuente de datos, pero no incluye la configuración de obtención de la información de la misma. Para configurar esta, se deberá seguir <a target='_blank' href='http://wiki.rediris.es/SIR2/SSp_directorios_LDAP'>esta documentación.</a>."
+    },
+    "step5_pdo_info": {
+        "es": "Esta configuración permitirá la conexión del IdP a la fuente de datos, pero no incluye la configuración de obtención de la información de la misma. Para configurar esta, se deberá seguir <a target='_blank' href='http://wiki.rediris.es/SIR2/SSp_bases_de_datos'>esta documentación.</a>."
     },
     "step5_ldap_title":{
         "es":"Configuración de fuente de datos de tipo LDAP"

--- a/hooks/hook_step1.php
+++ b/hooks/hook_step1.php
@@ -67,7 +67,7 @@ function idpinstaller_hook_step1(&$data) {
         $data['errors'][] = $ssphpobj->t('{idpinstaller:idpinstaller:step1_error_version}');
     } else {
         //Continuamos comprobando las extensiones de PHP
-        $extensions        = array("date", "dom", "hash", "libxml", "openssl", "pcre", "SPL", "zlib", "mcrypt", "posix");
+        $extensions        = array("date", "dom", "hash", "libxml", "openssl", "pcre", "SPL", "zlib", "posix");
         $failed_extensions = array();
         $loaded_extensions = get_loaded_extensions();
         foreach ($extensions as $extension) {

--- a/hooks/hook_step3.php
+++ b/hooks/hook_step3.php
@@ -73,12 +73,10 @@ function idpinstaller_hook_step3(&$data) {
             if (array_key_exists('ssphp_technicalcontact_name', $_REQUEST) && array_key_exists('ssphp_technicalcontact_email', $_REQUEST) && !empty($_REQUEST['ssphp_technicalcontact_name']) && !empty($_REQUEST['ssphp_technicalcontact_email'])) {
                 $filename                         = __DIR__ . '/../../../config/config.php';
                 include($filename);
-		
-                $algoritmo = 'sha512';
-		
-		$salt = shell_exec("tr -cd '[:alnum:][:blank:]' < /dev/urandom | head -c48; echo");
-		$config['auth.adminpassword'] = SimpleSAML\Utils\Crypto::pwHash($pass, strtoupper($algoritmo), $salt);
-		$config['secretsalt']		  = $salt;
+				
+        		$salt = shell_exec("tr -cd '[:alnum:][:blank:]' < /dev/urandom | head -c48; echo");
+        		$config['auth.adminpassword'] = SimpleSAML\Utils\Crypto::pwHash($pass);
+        		$config['secretsalt']		  = $salt;
                 $config['technicalcontact_name']  = $_REQUEST['ssphp_technicalcontact_name'];
                 $config['technicalcontact_email'] = $_REQUEST['ssphp_technicalcontact_email'];
                 $config['language.default']       = "es";
@@ -88,16 +86,16 @@ function idpinstaller_hook_step3(&$data) {
                 $config['enable.shib13-idp']      = false;
                 $config['enable.adfs-idp']        = false;
                 $config['enable.wsfed-sp']        = false;
-		/* Aniadido por Adrian Gomez en Julio de 2018
-		 Modificacion de directivas de configuración para dar mayor seguridad. #3
-		*/
-		$config['admin.protectindexpage'] = true;
-		$config['showerrors']		  = false;
-		$config['session.cookie.secure']  = true;
-		$config['trusted.url.domains']	  = array();
-		/*Fin de aniadido por Adrian Gomez*/
+        		/* Aniadido por Adrian Gomez en Julio de 2018
+        		 Modificacion de directivas de configuración para dar mayor seguridad. #3
+        		*/
+        		$config['admin.protectindexpage'] = true;
+        		$config['showerrors']		  = false;
+        		$config['session.cookie.secure']  = true;
+        		$config['trusted.url.domains']	  = array();
+        		/*Fin de aniadido por Adrian Gomez*/
 
-                $res                              = @file_put_contents($filename, '<?php  $config = ' . var_export($config, 1) . "; ?>");
+                $res = @file_put_contents($filename, '<?php  $config = ' . var_export($config, 1) . "; ?>");
                 if (!$res) {
                     $data['errors'][] = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step2_contact_save_error}');
                     $data['errors'][] = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step2_contact_save_error2}') . " <i>" . realpath($filename) . "</i>";

--- a/hooks/hook_step5.php
+++ b/hooks/hook_step5.php
@@ -67,17 +67,7 @@ function idpinstaller_hook_step5(&$data) {
                         $data['errors'][] = $ssphpobj->t('{idpinstaller:idpinstaller:step4_error}');
                     }
                 }
-            } else { //PARA LOS QUE QUEREMOS DESACTIVAR
-                if (file_exists($f . '/default-enable')) {
-
-                    @unlink($f . '/default-enable');
-                    @touch($f . '/default-disable');
-
-                    if (!file_exists($f . '/default-disable')) {
-                        $data['errors'][] = $ssphpobj->t('{idpinstaller:idpinstaller:step4_error}');
-                    }
-                }
-            }
+            } 
         }
     }
     if (count($modules_ko) > 0) {

--- a/hooks/hook_step6.php
+++ b/hooks/hook_step6.php
@@ -84,12 +84,18 @@ function idpinstaller_hook_step6(&$data) {
                     if (array_key_exists('sql_datasource', $config)) {
                         unset($config['sql_datasource']);
                     }
+
+                    saveSSPLDAPConfiguration($_REQUEST);
+                    
                     $res2 = @file_put_contents($filename, '<?php  $config = ' . var_export($config, 1) . "; ?>");
                     if (!$res2) {
                         $data['errors'][]            = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step2_contact_save_error}');
                         $data['errors'][]            = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step2_contact_save_error2}') . " <i>" . realpath($filename) . "</i>";
                         $data['datasource_selected'] = 'ldap';
                     }
+
+
+
                 }
                 return true;
             }

--- a/hooks/hook_step6.php
+++ b/hooks/hook_step6.php
@@ -85,7 +85,12 @@ function idpinstaller_hook_step6(&$data) {
                         unset($config['sql_datasource']);
                     }
 
-                    saveSSPLDAPConfiguration($_REQUEST);
+                    if($_REQUEST['ldap_enable_sspassword'] == 0){
+                        downloadSSPLdap();
+                        saveSSPLDAPConfiguration($_REQUEST);
+                    }
+
+                    
                     
                     $res2 = @file_put_contents($filename, '<?php  $config = ' . var_export($config, 1) . "; ?>");
                     if (!$res2) {

--- a/hooks/hook_step6.php
+++ b/hooks/hook_step6.php
@@ -81,6 +81,7 @@ function idpinstaller_hook_step6(&$data) {
                         'priv.password'     => NULL,
                         'authority'         => "urn:mace:".$_SERVER['HTTP_HOST'],
                     );
+
                     if (array_key_exists('sql_datasource', $config)) {
                         unset($config['sql_datasource']);
                     }

--- a/hooks/hook_step6.php
+++ b/hooks/hook_step6.php
@@ -81,17 +81,9 @@ function idpinstaller_hook_step6(&$data) {
                         'priv.password'     => NULL,
                         'authority'         => "urn:mace:".$_SERVER['HTTP_HOST'],
                     );
-
                     if (array_key_exists('sql_datasource', $config)) {
                         unset($config['sql_datasource']);
                     }
-
-                    if($_REQUEST['ldap_enable_sspassword'] == 0){
-                        downloadSSPLdap();
-                        saveSSPLDAPConfiguration($_REQUEST);
-                    }
-
-                    
                     if (array_key_exists('example-userpass', $config)) {
                         unset($config['example-userpass']);
                     }
@@ -101,9 +93,6 @@ function idpinstaller_hook_step6(&$data) {
                         $data['errors'][]            = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step2_contact_save_error2}') . " <i>" . realpath($filename) . "</i>";
                         $data['datasource_selected'] = 'ldap';
                     }
-
-
-
                 }
                 return true;
             }
@@ -145,7 +134,7 @@ function idpinstaller_hook_step6(&$data) {
                 }
                 return true;
             }
-        }else if (strcmp($ds_type, "config") == 0 && ($data['datasources'] == "all" || $data['datasources'] == "config")) {
+        }else if (strcmp($ds_type, "config") == 0) {
             if (array_key_exists('config_user', $_REQUEST) && !empty($_REQUEST['config_user'])
                     && array_key_exists('config_pass', $_REQUEST) && !empty($_REQUEST['config_pass'])
                     && array_key_exists('config_rol', $_REQUEST) && !empty($_REQUEST['config_rol'])) {

--- a/hooks/hook_step7.php
+++ b/hooks/hook_step7.php
@@ -231,7 +231,7 @@ function idpinstaller_hook_step7(&$data) {
         $data['errors2'][] = $data['ssphpobj']->t("{idpinstaller:idpinstaller:step1_remember_change_perms}");
     }
     if (count($data['errors2']) == 0) {
-        $url_meta = 'http://' . $_SERVER['HTTP_HOST'] . substr($_SERVER['SCRIPT_NAME'], 0, -24) . "saml2/idp/metadata.php?output=xhtml";
+        $url_meta = SimpleSAML\Utils\HTTP::getBaseURL() . "saml2/idp/metadata.php?output=xhtml";
         $data['info'][] = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step7_all_ok}');
         $data['info'][] = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step7_all_info_extra}') . " <a href='$url_meta' target='_blank'>" . $data['ssphpobj']->t('{idpinstaller:idpinstaller:step7_here}') . "</a>";
     } else {

--- a/hooks/hook_step9.php
+++ b/hooks/hook_step9.php
@@ -90,10 +90,10 @@ function idpinstaller_hook_step9(&$data) {
     $aux .= "<pre>&gt;" . $idpr_path . "</pre>";
     $data['info'][] = $aux;
 
-    $url_meta       = 'http://'.$_SERVER['HTTP_HOST'].substr($_SERVER['SCRIPT_NAME'], 0, -24) . "saml2/idp/metadata.php?output=xhtml";
+    $url_meta       = SimpleSAML\Utils\HTTP::getBaseURL() . "saml2/idp/metadata.php?output=xhtml";
     $data['info'][] = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step7_all_info_extra}') . " <a href='$url_meta' target='_blank'>" . $data['ssphpobj']->t('{idpinstaller:idpinstaller:step7_here}') . "</a>";
     
-    $url_init       = 'http://'.$_SERVER['HTTP_HOST'].substr($_SERVER['SCRIPT_NAME'], 0, -24) . "module.php/core/frontpage_welcome.php";
+    $url_init       = SimpleSAML\Module::getModuleURL("core/frontpage_welcome.php");
     $data['info'][] = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step9_url_init}') . " <a href='$url_init' target='_blank'>" . $data['ssphpobj']->t('{idpinstaller:idpinstaller:step7_here}') . "</a></br>";
     
     $data['info'][] = $data['ssphpobj']->t('{idpinstaller:idpinstaller:step9_remember_cert}').'<i>'.$cert_path.'</i>';

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -208,8 +208,6 @@ function saveSSPLDAPConfiguration($params){
 
         file_put_contents($filenameTarget, $content);
 
-    }else{
-
     }
 
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -151,3 +151,65 @@ function transaleXMLToSsPHP($xmldata){
     }
     return $output;
 }
+
+function saveSSPLDAPConfiguration($params){
+
+    $filenameSource = __DIR__ . '/../../../www/selfservicepassword/conf/config.inc.php';
+    $filenameTarget = __DIR__ . '/../../../www/selfservicepassword/conf/config.inc.local.php';
+
+    if(file_exists($filenameSource)){
+
+        $old = get_defined_vars();
+
+        include($filenameSource);
+
+        $new = get_defined_vars();
+
+        $fileSettings = array_diff($new, $old);
+
+        $keyphrase = "H3C31J3w0aSgCvfZuAPAInqKBBsyK6hH0RQEDm5Apj4PduQYmBv4m3myf6wF";
+
+        $newSettings = array(
+                        'ldap_url' => $params['ldap_hostname'].":".$params['ldap_port'],
+                        'ldap_starttls' => ($params['ldap_enable_tls'] == 0 ? TRUE : FALSE),
+                        'ldap_binddn' => $params['ldap_binddn'],
+                        'ldap_bindpw' => $params['ldap_bindpassword'],
+                        'ldap_base' => "dc=tuorganizacion,dc=es",
+                        'ldap_login_attribute' => "uid",
+                        'ldap_fullname_attribute' => "cn",
+                        'ldap_filter' => "(&(objectClass=person)($ldap_login_attribute={login}))",
+                        'keyphrase' => $keyphrase
+                    );
+
+        $fileSettings = array_merge($fileSettings, $newSettings);
+      
+        $content = "<?php \n";
+        
+        foreach ($fileSettings as $key => $value) {
+
+            if (gettype($value) == 'string' ){
+                $val = "'{$value}'";
+            } else if (gettype($value) == 'boolean' ){
+                if ($value == 0){
+                    $val = "FALSE";
+                } else {
+                    $val = "TRUE";
+                }
+            } else if (gettype($value) == 'NULL' ) {
+                $val = "NULL";
+            } else {
+                $val = "{$value}";
+            }
+
+            $content .= "$".$key." = ".$val."; \n";
+        }
+
+        $content .= "\n ?>";
+
+        file_put_contents($filenameTarget, $content);
+
+    }else{
+
+    }
+
+}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -202,6 +202,7 @@ function saveSSPLDAPConfiguration($params){
             }
 
             $content .= "$".$key." = ".$val."; \n";
+            
         }
 
         $content .= "\n ?>";
@@ -209,5 +210,30 @@ function saveSSPLDAPConfiguration($params){
         file_put_contents($filenameTarget, $content);
 
     }
+
+}
+
+function downloadSSPLdap(){
+
+    if (!file_exists(__DIR__ . '/../../../www/selfservicepassword')) {
+		$url = "https://ltb-project.org/archives/ltb-project-self-service-password-1.3.tar.gz";
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_BINARYTRANSFER, true);
+		$output = curl_exec($ch);
+		//Guardamos la imagen en un archivo
+		$fh = fopen(__DIR__ . '/../../../www/sspass.tar.gz', 'w');
+		fwrite($fh, $output);
+		fclose($fh);
+
+		$p = new PharData(__DIR__ . '/../../../www/sspass.tar.gz');
+		//$p->decompress();
+		$p->extractTo(__DIR__ . '/../../../www/sspass', null, true);
+
+		rename(__DIR__ . '/../../../www/sspass/ltb-project-self-service-password-1.3', __DIR__ . '/../../../www/selfservicepassword');
+
+		rmdir(__DIR__ . '/../../../www/sspass');
+		unlink(__DIR__ . '/../../../www/sspass.tar.gz');
+	}
 
 }

--- a/templates/step5.php
+++ b/templates/step5.php
@@ -110,7 +110,7 @@
                     <option value="0"><?php echo $this->t('{idpinstaller:idpinstaller:step5_anonbind_no}'); ?></option>
                 </select><br/>
             </p>            
-            <p>En el caso de realizar bind anónimo especifique el DN y password:</p>
+            <p><?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_bindtext}'); ?></p>
             <p>
                 <?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_binddn}'); ?><br/>
                 <input type="text" name="ldap_binddn" value="" style="width: 300px;"/><br/>
@@ -136,7 +136,7 @@
                 </select><br/>
             </p>   
             <p>
-                ¿Desea instalar y configurar la aplicación Self Service Password para que cada usuario pueda gestionar su contraseña?<br/>
+                <?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_sspassword}'); ?><br/>
                 <select name="ldap_enable_sspassword">
                     <option value="0"><?php echo $this->t('{idpinstaller:idpinstaller:step5_yes}'); ?></option>
                     <option value="1"><?php echo $this->t('{idpinstaller:idpinstaller:step5_no}'); ?></option>
@@ -162,7 +162,7 @@
                 <input type="password" name="pdo_password" value="" style="width: 300px;"/><br/>
             </p>
             <div class="caution" style="min-height:45px;">
-                <?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_info}'); ?>
+                <?php echo $this->t('{idpinstaller:idpinstaller:step5_pdo_info}'); ?>
             </div>
         </div>
         <input type="hidden" name="step" value="<?php echo $next_step; ?>"/>

--- a/templates/step5.php
+++ b/templates/step5.php
@@ -131,15 +131,13 @@
     } else if (strcmp($this->data['sir']['datasources'], "ldap") == 0) {
         $ldap = true;
         $pdo = false;
-        $conf = false;
+        $conf = true;
         unset($options['pdo']);
-        unset($options['config']);
     } else if (strcmp($this->data['sir']['datasources'], "pdo") == 0) {
         $pdo  = true;
         $ldap = false;
-        $conf = false;
+        $conf = true;
         unset($options['ldap']);
-        unset($options['config']);
     } else if(strcmp($this->data['sir']['datasources'], "config") == 0){
         $pdo  = false;
         $ldap = false;
@@ -188,7 +186,7 @@
                     <option value="0"><?php echo $this->t('{idpinstaller:idpinstaller:step5_anonbind_no}'); ?></option>
                 </select><br/>
             </p>            
-            <p><?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_bindtext}'); ?></p>
+            <p>En el caso de realizar bind anónimo especifique el DN y password:</p>
             <p>
                 <?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_binddn}'); ?><br/>
                 <input type="text" name="ldap_binddn" value="" style="width: 300px;"/><br/>
@@ -213,13 +211,6 @@
                     <option value="1"><?php echo $this->t('{idpinstaller:idpinstaller:step5_no}'); ?></option>
                 </select><br/>
             </p>   
-            <p>
-                <?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_sspassword}'); ?><br/>
-                <select name="ldap_enable_sspassword">
-                    <option value="0"><?php echo $this->t('{idpinstaller:idpinstaller:step5_yes}'); ?></option>
-                    <option value="1"><?php echo $this->t('{idpinstaller:idpinstaller:step5_no}'); ?></option>
-                </select><br/>
-            </p>
             <div class="caution" style="min-height:45px;">
                 <?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_info}'); ?>
             </div>
@@ -240,7 +231,7 @@
                 <input type="password" name="pdo_password" value="" style="width: 300px;"/><br/>
             </p>
             <div class="caution" style="min-height:45px;">
-                <?php echo $this->t('{idpinstaller:idpinstaller:step5_pdo_info}'); ?>
+                <?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_info}'); ?>
             </div>
         </div>
 

--- a/templates/step5.php
+++ b/templates/step5.php
@@ -135,6 +135,13 @@
                     <option value="1"><?php echo $this->t('{idpinstaller:idpinstaller:step5_no}'); ?></option>
                 </select><br/>
             </p>   
+            <p>
+                ¿Desea instalar y configurar la aplicación Self Service Password para que cada usuario pueda gestionar su contraseña?<br/>
+                <select name="ldap_enable_sspassword">
+                    <option value="0"><?php echo $this->t('{idpinstaller:idpinstaller:step5_yes}'); ?></option>
+                    <option value="1"><?php echo $this->t('{idpinstaller:idpinstaller:step5_no}'); ?></option>
+                </select><br/>
+            </p>
             <div class="caution" style="min-height:45px;">
                 <?php echo $this->t('{idpinstaller:idpinstaller:step5_ldap_info}'); ?>
             </div>


### PR DESCRIPTION
En la rama development he corregido el problema con el 'metadata.sign.algorithm'. Ahora ya está configurado en el fichero template de configuración. Una vez esta modificación este en release está propiedad ya estará definida correctamente por defecto.

Por otro parte, en esa misma rama development, he corregido un problema que ocurría al aplicar ExampleAuth cuando LDAP no esta activo.

Esa rama también tiene lo del Self Service Password para LDAP. Puedes ver en correos anteriores lo que contiene la rama, mis cuestiones...
